### PR TITLE
Updates to V3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,18 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
-    container:
-        image: quantconnect/lean:foundation
+    runs-on: ubuntu-20.04    
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Free space
+        run: df -h && rm -rf /opt/hostedtoolcache* && df -h
+
+      - name: Pull Foundation Image
+        uses: addnab/docker-run-action@v3
+        with:
+          image: quantconnect/lean:foundation
 
       - name: BuildDataSource
         run: dotnet build ./QuantConnect.DataSource.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1

--- a/QuantConnect.DataSource.csproj
+++ b/QuantConnect.DataSource.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="QuantConnect.Common" Version="2.5.*" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RegalyticsRegulatoryArticle.cs
+++ b/RegalyticsRegulatoryArticle.cs
@@ -34,7 +34,7 @@ namespace QuantConnect.DataSource
         public static int DataSourceId { get; } = 2030;
 
         [JsonProperty(PropertyName = "id")]
-        public int Id { get; set; }
+        public string Id { get; set; }
 
         [JsonProperty(PropertyName = "title")]
         public string Title { get; set; }

--- a/tests/RegalyticsRegulatoryArticleTests.cs
+++ b/tests/RegalyticsRegulatoryArticleTests.cs
@@ -55,7 +55,18 @@ namespace QuantConnect.DataLibrary.Tests
 
             AssertAreEqual(expected, result);
         }
-        
+
+        [Test]
+        public void BackwardCompatibilityToV2()
+        {
+            // The Id is a number in v2
+            var line = "{\"id\": 2051381, \"title\": \"House of Representatives Study Bill HSB692: A bill for an act relating to school security, including by modifying provisions related to the issuance of school bonds, requiring schools to conduct school safety reviews and have access to the statewide interoperable communications system, establishing the school emergency radio access grant program and the firearm detection software grant program within the department of homeland security and emergency management, requiring the department of public (I)\", \"summary\": \"Introduced on 2024-02-12. House Study Bill 692 is a piece of legislation in Iowa that focuses on school security. It includes provisions related to the issuance of school bonds, requires schools to conduct safety reviews and have access to a statewide communications system, establishes grant programs for school emergency radio access and firearm detection software, and requires the Department of Public Safety to convene a task force on school safety standards. The bill also appropriates funds for these programs and specifies that the state cost of compliance with the legislation will be paid by school districts from state school foundation aid. The bill takes effect upon enactment. (99IA202320242022HSB692)\", \"status\": \"New\", \"classification\": \"State\", \"filing_type\": \"Single\", \"in_federal_register\": false, \"federal_register_number\": null, \"regalytics_alert_id\": \"99IA2022HSB69225120240212\", \"proposed_comments_due_date\": null, \"original_publication_date\": \"2024-02-12\", \"federal_register_publication_date\": null, \"rule_effective_date\": null, \"latest_update\": \"2024-02-12\", \"alert_type\": \"Study Bill\", \"docket_file_number\": \"\", \"order_notice\": \"\", \"sec_release_number\": \"\", \"agencies\": [\"Iowa House of Representatives\"], \"sector_type\": [{\"name\": \"Financial\"}], \"tags\": [{\"name\": \"All State and Federal Legislatures\"}, {\"name\": \"Introduced Bill\"}], \"subtype_classification\": [{\"name\": \"House of Representatives Study Bill\", \"higher_order_alert_classification\": {\"name\": \"Rule\"}}], \"pdf_url\": \"https://www.legis.iowa.gov/legislation/BillBook?ga=90&ba=HSB692\", \"created_at\": \"2024-02-12T22:31:40.567008\", \"states\": {\"United States\": [\"Iowa\"]}}";
+            var instance = new RegalyticsRegulatoryArticle();
+            var config = new SubscriptionDataConfig(instance.GetType(), Symbol.None, Resolution.Daily, TimeZones.Utc, TimeZones.Utc, false, false, false);
+            var data = instance.Reader(config, line, new DateTime(2024, 2, 12), false) as RegalyticsRegulatoryArticle;
+            Assert.AreEqual("2051381", data.Id);
+        }
+
         private void AssertAreEqual(object expected, object result, bool filterByCustomAttributes = false)
         {
             foreach (var propertyInfo in expected.GetType().GetProperties())
@@ -80,7 +91,7 @@ namespace QuantConnect.DataLibrary.Tests
                 Time = DateTime.Today,
                 DataType = MarketDataType.Base,
 
-                Id = 0,
+                Id = "0",
                 Title = "string",
                 Summary = "string",
                 Status = "string",
@@ -111,7 +122,7 @@ namespace QuantConnect.DataLibrary.Tests
                     Time = DateTime.Today,
                     DataType = MarketDataType.Base,
 
-                    Id = 0,
+                    Id = "0",
                     Title = "string",
                     Summary = "string",
                     Status = "string",
@@ -136,7 +147,7 @@ namespace QuantConnect.DataLibrary.Tests
                     Time = DateTime.Today,
                     DataType = MarketDataType.Base,
 
-                    Id = 0,
+                    Id = "0",
                     Title = "string",
                     Summary = "string",
                     Status = "string",


### PR DESCRIPTION
The new endpoint, https://api.regalytics.ai/api/v3, changes the format: 'articles' to 'results', 'states' to 'state' and 'countries' to 'country'. The 'id' from 'int' to 'string'.

https://documenter.getpostman.com/view/15670322/TzRVeRER#a2fd87cb-f4a7-4669-81f5-ef503658ea06